### PR TITLE
Added extra look and feel options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 1.2.0
+
+## Features
+
+- GCD underlay color settings include alpha
+- option to change borders
+- text on the left and right can be swapped (doesn't imports old setting)
+- texture on bar have a fixed scale by default and is not rescaled to the current progress, can be changed to old look
+
+## Fixes
+
+- extra logic for more haste detection for GCD with Flash of Light
+
 # 1.1.0
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Fixes
 
+- text on the left and right now always includes one digit after dot
 - extra logic for more haste detection for GCD with Flash of Light
 
 # 1.1.0

--- a/SwedgeTimer.toc
+++ b/SwedgeTimer.toc
@@ -2,7 +2,7 @@
 ## Title: SwedgeTimer
 ## Notes: Seal twisting timer bar for BCC Ret Paladins.
 ## Author: Swedge
-## Version: 1.2.0
+## Version: "@project-version@"
 ## DefaultState: enabled
 ## OptDeps: Ace3, LibSharedMedia-3.0, LibStub
 ## SavedVariables: SwedgeTimerDB

--- a/SwedgeTimer.toc
+++ b/SwedgeTimer.toc
@@ -2,7 +2,7 @@
 ## Title: SwedgeTimer
 ## Notes: Seal twisting timer bar for BCC Ret Paladins.
 ## Author: Swedge
-## Version: 1.1.0
+## Version: 1.2.0
 ## DefaultState: enabled
 ## OptDeps: Ace3, LibSharedMedia-3.0, LibStub
 ## SavedVariables: SwedgeTimerDB

--- a/bar.lua
+++ b/bar.lua
@@ -105,19 +105,14 @@ st.bar.init_bar_visuals = function()
     frame.left_text:SetShadowOffset(1,-1)
     frame.left_text:SetJustifyV("CENTER")
     frame.left_text:SetJustifyH("LEFT")
-    if not db.show_attack_speed_text then
-        frame.left_text:Hide()
-    end
 
     frame.right_text = frame:CreateFontString(nil, "OVERLAY")
     frame.right_text:SetShadowColor(0.0,0.0,0.0,1.0)
     frame.right_text:SetShadowOffset(1,-1)
     frame.right_text:SetJustifyV("CENTER")
     frame.right_text:SetJustifyH("RIGHT")
-    if not db.show_swing_timer_text then
-        frame.right_text:Hide()
-    end
     st.set_fonts()
+    st.set_texts()
 
     -- Create the line markers
     frame.twist_line = frame:CreateLine() -- the twist window marker
@@ -176,15 +171,18 @@ st.bar.update_visuals_on_update = function()
     -- Update the main bar's width
     local timer_width = math.min(db.bar_width - (db.bar_width * (timer / speed)), db.bar_width)
     frame.bar:SetWidth(timer_width)
-
+	
+	-- Set texts
+	local lookup = {
+		attack_speed=tostring(st.utils.simple_round(speed, 0.1)),
+		swing_timer=tostring(st.utils.simple_round(timer, 0.1)),
+	}
+	local left = lookup[db.left_text]
+	local right = lookup[db.right_text]
+	
     -- Update the main bars text, hide right text if bar full
-    frame.left_text:SetText(tostring(st.utils.simple_round(speed, 0.1)))
-    frame.right_text:SetText(tostring(st.utils.simple_round(timer, 0.1)))
-    if st.bar.draw_right_text() then
-        frame.right_text:Show()
-    else
-        frame.right_text:Hide()
-    end
+    frame.left_text:SetText(left)
+    frame.right_text:SetText(right)
 
     -- If SoC/SoR, bar colour is time/context sensitive. Deal with that here.
     if st.player.is_twist_seal_active() then
@@ -581,13 +579,6 @@ end
 
 -- draw the right text or not
 st.bar.draw_right_text = function()
-    local db = ST.db.profile
-    if not db.show_swing_timer_text then
-        return false
-    end
-    if st.player.swing_timer == 0 then
-        return false
-    end
     return true
 end
 

--- a/bar.lua
+++ b/bar.lua
@@ -178,8 +178,8 @@ st.bar.update_visuals_on_update = function()
 	
 	-- Set texts
 	local lookup = {
-		attack_speed=tostring(st.utils.simple_round(speed, 0.1)),
-		swing_timer=tostring(st.utils.simple_round(timer, 0.1)),
+		attack_speed=format("%.1f", st.utils.simple_round(speed, 0.1)),
+		swing_timer=format("%.1f", st.utils.simple_round(timer, 0.1)),
 	}
 	local left = lookup[db.left_text]
 	local right = lookup[db.right_text]

--- a/bar.lua
+++ b/bar.lua
@@ -166,11 +166,15 @@ st.bar.update_visuals_on_update = function()
     local frame = st.bar.frame
     local speed = st.player.current_weapon_speed
     local timer = st.player.swing_timer
+	local progress = 1 - math.max(0, math.min(1, timer / speed))
     local db = ST.db.profile
 
     -- Update the main bar's width
-    local timer_width = math.min(db.bar_width - (db.bar_width * (timer / speed)), db.bar_width)
+    local timer_width = db.bar_width * progress
     frame.bar:SetWidth(timer_width)
+	if not db.bar_texture_scale then
+		frame.bar:SetTexCoord(0, progress, 0, 1)
+	end
 	
 	-- Set texts
 	local lookup = {

--- a/bar.lua
+++ b/bar.lua
@@ -68,6 +68,7 @@ st.bar.init_bar_visuals = function()
 
     -- These lines function as the 
     local tv = st.get_thickness_value()
+	tv = tv - 2
     frame.backplane:SetPoint('TOPLEFT', -1*tv, tv)
     frame.backplane:SetPoint('BOTTOMRIGHT', tv, -1*tv)
     
@@ -75,9 +76,9 @@ st.bar.init_bar_visuals = function()
     -- print(SML:Fetch('statusbar', db.backplane_texture_key))
     frame.backplane.backdropInfo = {
         bgFile = SML:Fetch('statusbar', db.backplane_texture_key),
-        edgeFile = nil,
+		edgeFile = SML:Fetch('border', db.border_texture_key),
         tile = true, tileSize = 16, edgeSize = 16, 
-        insets = { left = 8, right = 8, top = 8, bottom = 8}
+        insets = { left = 6, right = 6, top = 6, bottom = 6}
     }
     frame.backplane:ApplyBackdrop()
     frame.backplane:SetBackdropColor(0, 0, 0, db.backplane_alpha)

--- a/bar.lua
+++ b/bar.lua
@@ -64,25 +64,9 @@ st.bar.init_bar_visuals = function()
 
     -- Create the backplane and border
     frame.backplane = CreateFrame("Frame", addon_name .. "BarBackdropFrame", frame, "BackdropTemplate")
+    st.configure_bar_outline()
     frame.backplane:SetFrameStrata('LOW')
-
-    -- These lines function as the 
-    local tv = st.get_thickness_value()
-	tv = tv - 2
-    frame.backplane:SetPoint('TOPLEFT', -1*tv, tv)
-    frame.backplane:SetPoint('BOTTOMRIGHT', tv, -1*tv)
-    
-
-    -- print(SML:Fetch('statusbar', db.backplane_texture_key))
-    frame.backplane.backdropInfo = {
-        bgFile = SML:Fetch('statusbar', db.backplane_texture_key),
-		edgeFile = SML:Fetch('border', db.border_texture_key),
-        tile = true, tileSize = 16, edgeSize = 16, 
-        insets = { left = 6, right = 6, top = 6, bottom = 6}
-    }
-    frame.backplane:ApplyBackdrop()
     frame.backplane:SetBackdropColor(0, 0, 0, db.backplane_alpha)
-
 
     -- Create the swing timer bar
     frame.bar = frame:CreateTexture(nil,"ARTWORK")
@@ -127,23 +111,6 @@ st.bar.init_bar_visuals = function()
     frame.judgement_line:SetDrawLayer("OVERLAY", -1)
     st.set_markers()
 
-
-    -- -- Create the seal cooldown frame.
-    -- local myFrame = CreateFrame("Frame", nil, UIParent)
-    -- myFrame:SetSize(80, 80)
-    -- myFrame:SetPoint("CENTER")
-    -- local myTexture = myFrame:CreateTexture()
-    -- myTexture:SetAllPoints()
-    -- myTexture:SetTexture(132347)
-    -- myTexture:SetTexCoord(0.1, 0.9, 0.1, 0.9);
-    -- local myCooldown = CreateFrame("Cooldown", "myCooldown", myFrame, "CooldownFrameTemplate")
-    -- myCooldown:SetAllPoints()
-
-    -- frame.seal_frame = CreateFrame("Frame", addon_name .. "SealFrame", frame, "CooldownFrameTemplate")
-    -- frame.seal_frame:SetSize(30, 30)
-    -- frame.seal_frame:SetPoint("RIGHT", 100, 0)
-    -- frame.seal_frame.texture = seal_frame.CreateTexture()
-    -- frame.seal_frame.texture:
 	frame:Show()
     if st.debug then print('Successfully initialised all bar visuals.') end
 end
@@ -172,9 +139,7 @@ st.bar.update_visuals_on_update = function()
     -- Update the main bar's width
     local timer_width = db.bar_width * progress
     frame.bar:SetWidth(timer_width)
-	if not db.bar_texture_scale then
-		frame.bar:SetTexCoord(0, progress, 0, 1)
-	end
+	frame.bar:SetTexCoord(0, progress, 0, 1)
 	
 	-- Set texts
 	local lookup = {

--- a/core.lua
+++ b/core.lua
@@ -87,7 +87,6 @@ SwedgeTimer.defaults = {
         -- gcd_texture_key = SML.DefaultMedia.statusbar,
         -- backplane_texture_key = SML.DefaultMedia.statusbar,
 		bar_texture_key = "Solid",
-		bar_texture_scale = false,
         gcd_texture_key = "Solid",
         backplane_texture_key = "Solid",
         border_texture_key = "None",
@@ -773,15 +772,6 @@ SwedgeTimer.options = {
 						SwedgeTimer.db.profile.bar_texture_key = key
 						st.bar.frame.bar:SetTexture(SML:Fetch('statusbar', key))
 					end
-				},
-
-				bar_texture_scale = {
-					type="toggle",
-					order = 2.1,
-					name = "Bar texture scale",
-					desc = "Enables the texture of the swing bar to be scaled to the current progress. Othewise it stays constant to the full width.",
-					get = "GetValue",
-					set = "SetValue",
 				},
 				
 				gcd_texture_key = {

--- a/core.lua
+++ b/core.lua
@@ -87,6 +87,7 @@ SwedgeTimer.defaults = {
         -- gcd_texture_key = SML.DefaultMedia.statusbar,
         -- backplane_texture_key = SML.DefaultMedia.statusbar,
 		bar_texture_key = "Solid",
+		bar_texture_scale = false,
         gcd_texture_key = "Solid",
         backplane_texture_key = "Solid",
         border_texture_key = "None",
@@ -103,8 +104,6 @@ SwedgeTimer.defaults = {
 		font_outline_key = "outline",
         left_text = "attack_speed",
         right_text = "swing_timer",
-        show_attack_speed_text = true,
-        show_swing_timer_text = true,
 
 		-- Marker settings
 		marker_width = 3,
@@ -775,6 +774,15 @@ SwedgeTimer.options = {
 						st.bar.frame.bar:SetTexture(SML:Fetch('statusbar', key))
 					end
 				},
+
+				bar_texture_scale = {
+					type="toggle",
+					order = 2.1,
+					name = "Bar texture scale",
+					desc = "Enables the texture of the swing bar to be scaled to the current progress. Othewise it stays constant to the full width.",
+					get = "GetValue",
+					set = "SetValue",
+				},
 				
 				gcd_texture_key = {
 					order = 3,
@@ -789,6 +797,12 @@ SwedgeTimer.options = {
 						st.bar.frame.gcd_bar:SetTexture(SML:Fetch('statusbar', key))
 						st.bar.set_gcd_bar_width()
 					end
+				},
+
+				placeholder_1 = {
+					type="description",
+					order = 3.1,
+					name = "",
 				},
 		
 				backplane_texture_key = {
@@ -838,8 +852,15 @@ SwedgeTimer.options = {
 						st.bar.frame.backplane:SetPoint('BOTTOMRIGHT', val, -1*val)
 					end
 				},
-				border_texture_key = {
+
+				placeholder_2 = {
+					type="description",
 					order = 5.2,
+					name = "",
+				},
+				
+				border_texture_key = {
+					order = 6,
 					type = "select",
 					name = "Border",
 					desc = "The border texture of the swing bar.",

--- a/core.lua
+++ b/core.lua
@@ -137,14 +137,14 @@ SwedgeTimer.defaults = {
 }
 
 local outline_map = {
-	none="",
+	_none="",
 	outline="OUTLINE",
 	thick_outline="THICKOUTLINE",
 }
 
 local outlines = {
-	none="None",
-	attacs="Attach",
+	_none="None",
+	outline="Outline",
 	thick_outline="Thick Outline",
 }
 

--- a/core.lua
+++ b/core.lua
@@ -101,6 +101,8 @@ SwedgeTimer.defaults = {
 		font_color = {1.0, 1.0, 1.0, 1.0},
 		text_font = SML.DefaultMedia.font,
 		font_outline_key = "outline",
+        left_text = "attack_speed",
+        right_text = "swing_timer",
         show_attack_speed_text = true,
         show_swing_timer_text = true,
 
@@ -143,8 +145,14 @@ local outline_map = {
 
 local outlines = {
 	none="None",
-	outline="Outline",
+	attacs="Attach",
 	thick_outline="Thick Outline",
+}
+
+local texts = {
+	_none="Not shown",
+	attack_speed="Attack speed",
+	swing_timer="Swing Timer",
 }
 
 local gcd_padding_modes = {
@@ -232,6 +240,10 @@ local set_fonts = function()
 end
 st.set_fonts = set_fonts
 
+local set_texts = function()
+end
+st.set_texts = set_texts
+
 local set_bar_size = function()
 	local db = SwedgeTimer.db.profile
 	local frame = st.bar.frame
@@ -242,6 +254,7 @@ local set_bar_size = function()
 	-- frame.gcd_bar:SetWidth(db.bar_width)
 	frame.gcd_bar:SetHeight(db.bar_height)
 	set_fonts()
+	set_texts()
 	st.set_markers()
 end
 
@@ -902,34 +915,30 @@ SwedgeTimer.options = {
 						set_fonts()
 					end,
 				},
-				show_attack_speed_text = {
-					type="toggle",
+				left_text = {
+					type="select",
 					order = 9.1,
-					name = "Attack speed text",
-					desc = "Shows the player's current attack speed at the left of the swing timer bar.",
+					values=texts,
+					style="dropdown",
+					name = "Left text",
+					desc = "What to shows on the left of the swing timer bar.",
 					get = "GetValue",
 					set = function(self, key)
-						SwedgeTimer.db.profile.show_attack_speed_text = key
-						if key then
-							st.bar.frame.left_text:Show()
-						else
-							st.bar.frame.left_text:Hide()
-						end
-					end,
+						SwedgeTimer.db.profile.left_text = key
+						set_texts()
+					end
 				},
-				show_swing_timer_text = {
-					type="toggle",
-					order = 9.12,
-					name = "Swing timer text",
-					desc = "Shows the remaining time on the player's swing on the right of the swing bar.",
+				right_text = {
+					type="select",
+					order = 9.1,
+					values=texts,
+					style="dropdown",
+					name = "Right text",
+					desc = "What to shows on the right of the swing timer bar.",
 					get = "GetValue",
 					set = function(self, key)
-						SwedgeTimer.db.profile.show_swing_timer_text = key
-						if key then
-							st.bar.frame.right_text:Show()
-						else
-							st.bar.frame.right_text:Hide()
-						end
+						SwedgeTimer.db.profile.right_text = key
+						set_texts()
 					end,
 				},
 				

--- a/core.lua
+++ b/core.lua
@@ -199,7 +199,7 @@ local set_fonts = function()
 	frame.left_text:SetFont(font_path, db.font_size, opt_string)
 	frame.right_text:SetFont(font_path, db.font_size, opt_string)
 	frame.left_text:SetPoint("TOPLEFT", 2, -(db.bar_height / 2) + (db.font_size / 2))
-	frame.right_text:SetPoint("TOPRIGHT", 2, -(db.bar_height / 2) + (db.font_size / 2))
+	frame.right_text:SetPoint("TOPRIGHT", -2, -(db.bar_height / 2) + (db.font_size / 2))
 	frame.left_text:SetTextColor(unpack(db.font_color))
 	frame.right_text:SetTextColor(unpack(db.font_color))
 end

--- a/core.lua
+++ b/core.lua
@@ -1114,7 +1114,7 @@ SwedgeTimer.options = {
 					type="color",
 					name="Underlay color",
 					desc="The color of the GCD underlay.",
-					hasAlpha=false,
+					hasAlpha=true,
 					get = function()
 						local tab = SwedgeTimer.db.profile.bar_color_gcd
 						return tab[1], tab[2], tab[3], tab[4]

--- a/core.lua
+++ b/core.lua
@@ -89,6 +89,7 @@ SwedgeTimer.defaults = {
 		bar_texture_key = "Solid",
         gcd_texture_key = "Solid",
         backplane_texture_key = "Solid",
+        border_texture_key = "None",
 
 		backplane_alpha = 0.85,
         
@@ -819,8 +820,24 @@ SwedgeTimer.options = {
 						local val = st.bar_outline_thicknesses[key]
 						SwedgeTimer.db.profile.backplane_outline_offset = val
 						-- print(val)
+						val = val - 2
 						st.bar.frame.backplane:SetPoint('TOPLEFT', -1*val, val)
 						st.bar.frame.backplane:SetPoint('BOTTOMRIGHT', val, -1*val)
+					end
+				},
+				border_texture_key = {
+					order = 5.2,
+					type = "select",
+					name = "Border",
+					desc = "The border texture of the swing bar.",
+					dialogControl = "LSM30_Border",
+					values = SML:HashTable("border"),
+					get = function(info) return SwedgeTimer.db.profile.border_texture_key or SML.DefaultMedia.border end,
+					set = function(self, key)
+						SwedgeTimer.db.profile.border_texture_key = key
+						st.bar.frame.backplane.backdropInfo.edgeFile = SML:Fetch('border', key)
+						st.bar.frame.backplane:ApplyBackdrop()
+						st.bar.frame.backplane:SetBackdropColor(0,0,0, SwedgeTimer.db.profile.backplane_alpha)
 					end
 				},
 

--- a/player.lua
+++ b/player.lua
@@ -346,11 +346,21 @@ st.player.calculate_spell_GCD_duration = function()
     if st.player.has_breath_haste then
         current = current * (1/1.25)
     end
+	
+	-- get FoL speed, should normally equivalent to GCD unless some debuff
+	local spellFoL, timeFoL = 19750
+	local _, _, _, timeFoL, _,  _, _ = GetSpellInfo(spellFoL)
+	timeFoL = timeFoL or 1500
+	timeFoL = timeFoL / 1000
+	
+	-- get the minimum of 2 logics
+	current = math.min(current, timeFoL)
 
     -- minimum GCD for paladins in 1s
     if current < 1 then
         current = 1.0
     end
+	
     -- round to 3 decimal places
     current = floor(current, 0.001)
     st.player.spell_gcd_duration = current


### PR DESCRIPTION
GCD underlay color settings include alpha
Option to change borders
Text on the left and right can be swapped (doesn't imports old setting)
Texture on bar have a fixed scale by default and is not rescaled to the current progress, can be changed to old look
Extra logic for more haste detection for GCD with Flash of Light